### PR TITLE
ext: rename sha3 to keccak for clarity

### DIFF
--- a/ext/digest/extconf.rb
+++ b/ext/digest/extconf.rb
@@ -28,4 +28,4 @@ have_header! 'string.h'
 
 have_func! 'rb_str_set_len'
 
-create_makefile 'digest/sha3' or exit 1
+create_makefile 'digest/keccak' or exit 1

--- a/keccak.gemspec
+++ b/keccak.gemspec
@@ -3,13 +3,13 @@
 lib = File.expand_path('lib', __dir__).freeze
 $LOAD_PATH.unshift lib unless $LOAD_PATH.include? lib
 
-require 'digest/sha3/version'
+require 'digest/keccak/version'
 
 Gem::Specification.new do |spec|
   spec.name = "keccak"
-  spec.version = Digest::SHA3::VERSION
-  spec.summary = "The Keccak (SHA-3) hash used by Ethereum."
-  spec.description = "The Keccak (SHA-3) hash used by Ethereum. This does not implement the final FIPS202 standard, today known as SHA3 but rather an early version, commonly referred to as Keccak."
+  spec.version = Digest::Keccak::VERSION
+  spec.summary = "The Keccak (SHA3) hash used by Ethereum."
+  spec.description = "The Keccak (SHA3) hash used by Ethereum. This does not implement the final FIPS202 standard, today known as SHA3 but rather an early version, commonly referred to as Keccak."
   spec.homepage = "https://github.com/q9f/keccak.rb"
   spec.authors = ["Afri Schoedon", "Alex Kotov", "Chris Metcalfe", "Hongli Lai (Phusion)", "Keccak authors"]
   spec.email = "%w[ruby@q9f.cc]"

--- a/lib/digest/keccak/version.rb
+++ b/lib/digest/keccak/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Digest
-  class SHA3
-    VERSION = '1.2.2'
+  class Keccak
+    VERSION = '1.3.0'
   end
 end

--- a/test/generate_tests.rb
+++ b/test/generate_tests.rb
@@ -19,7 +19,7 @@ def generate
 
     require 'test/unit'
 
-    class SHA3Tests < Test::Unit::TestCase
+    class KeccakTests < Test::Unit::TestCase
   }
 
   FILES.each do |path, hashlen|
@@ -34,7 +34,7 @@ def generate
           name = File.basename(path).split('.')[0]
           puts %Q{
             def test_#{name}_#{length}
-              inst = Digest::SHA3.new(#{hashlen})
+              inst = Digest::Keccak.new(#{hashlen})
               inst.update(#{msg_raw.inspect})
               assert_equal #{md.inspect}, inst.hexdigest
             end

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -2,7 +2,7 @@
 
 $LOAD_PATH.unshift(File.expand_path("lib"))
 $LOAD_PATH.unshift(File.expand_path("ext"))
-require 'digest/sha3'
+require 'digest/keccak'
 require File.expand_path('test/test_usage')
 require File.expand_path('test/test_vectors')
 require File.expand_path('test/test_new')

--- a/test/test_new.rb
+++ b/test/test_new.rb
@@ -2,9 +2,9 @@
 
 require 'test/unit'
 
-class SHA3NewTests < Test::Unit::TestCase
+class KeccakNewTests < Test::Unit::TestCase
   def test_singleton_method_hexdigest_256_empty
-    result = Digest::SHA3.hexdigest '', 256
+    result = Digest::Keccak.hexdigest '', 256
     assert_instance_of String, result
     assert_equal 'c5d2460186f7233c927e7db2dcc703c0' \
                  'e500b653ca82273b7bfad8045d85a470',
@@ -12,7 +12,7 @@ class SHA3NewTests < Test::Unit::TestCase
   end
 
   def test_singleton_method_hexdigest_256_sample
-    result = Digest::SHA3.hexdigest 'sample', 256
+    result = Digest::Keccak.hexdigest 'sample', 256
     assert_instance_of String, result
     assert_equal 'b80204f7e9243e4fca5489740ccd31dc' \
                  'd0a54619a7f4165cee73c191ef7271a1',

--- a/test/test_usage.rb
+++ b/test/test_usage.rb
@@ -2,9 +2,9 @@
 
 require 'test/unit'
 
-class SHA3UsageTest < Test::Unit::TestCase
+class KeccakUsageTest < Test::Unit::TestCase
   def init(hashsize = 512)
-    @digest = Digest::SHA3.new(hashsize)
+    @digest = Digest::Keccak.new(hashsize)
   end
 
   def test_copy
@@ -18,7 +18,7 @@ class SHA3UsageTest < Test::Unit::TestCase
 
   def test_class_methods
     assert_equal 'a9cab59eb40a10b246290f2d6086e32e3689faf1d26b470c899f2802',
-      Digest::SHA3.hexdigest("\xcc", 224)
+      Digest::Keccak.hexdigest("\xcc", 224)
   end
 
   def test_update


### PR DESCRIPTION
```ruby
digest = Digest::Keccak.new
```

Instead of SHA3 to avoid confusion with SHA3 standard.