### PR TITLE
Include stdbool header to define bool type

### DIFF
--- a/ext/digest/keccak.c
+++ b/ext/digest/keccak.c
@@ -1,4 +1,5 @@
 #include "ruby.h"
+#include <stdbool.h>
 #ifdef HAVE_RUBY_DIGEST_H
 #include "ruby/digest.h"
 #else


### PR DESCRIPTION
- include `<stdbool.h>` in the C extension so `bool` is defined on newer compilers
- fix https://github.com/q9f/eth.rb/issues/375